### PR TITLE
Update docs for CoreDNS info

### DIFF
--- a/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-alpha.md
@@ -224,7 +224,7 @@ Alternatively, you can use [kubeadm config](kubeadm-config.md).
 You can install all the available addons with the `all` subcommand, or 
 install them selectively.
 
-Please note that if kubeadm is invoked with `--feature-gates=CoreDNS`,  CoreDNS is installed instead of `kube-dns`.
+Please note that if kubeadm is invoked with `--feature-gates=CoreDNS=true`,  [CoreDNS](https://coredns.io/) is installed instead of `kube-dns`.
 
 {% capture addon-all %}
 {% include_relative generated/kubeadm_alpha_phase_addon_all.md %}

--- a/docs/reference/setup-tools/kubeadm/kubeadm-init.md
+++ b/docs/reference/setup-tools/kubeadm/kubeadm-init.md
@@ -75,7 +75,7 @@ following steps:
 
    See [kubeadm join](kubeadm-join.md) for additional info.
 
-1. Installs the internal DNS server and the kube-proxy addon components via the API server.  
+1. Installs the internal DNS server (kube-dns) and the kube-proxy addon components via the API server. If kubeadm is invoked with --feature-gates=CoreDNS=true, then [CoreDNS](https://coredns.io/) will be installed as the default internal DNS server instead of kube-dns.  
    Please note that although the DNS server is deployed, it will not be scheduled until CNI is installed.
 
 1. If `kubeadm init` is invoked with the alpha self-hosting feature enabled,
@@ -409,7 +409,7 @@ Here `v1.8.x` means the "latest patch release of the v1.8 branch".
 
 `${ARCH}` can be one of: `amd64`, `arm`, `arm64`, `ppc64le` or `s390x`.
 
-If using `--feature-gates=CoreDNS` image `coredns/coredns:1.0.0` is required (instead of the three `k8s-dns-*` images).
+If using `--feature-gates=CoreDNS=true` image `coredns/coredns:1.0.2` is required (instead of the three `k8s-dns-*` images).
 
 ### Automating kubeadm
 

--- a/docs/tasks/administer-cluster/kubeadm-upgrade-1-9.md
+++ b/docs/tasks/administer-cluster/kubeadm-upgrade-1-9.md
@@ -114,6 +114,8 @@ _____________________________________________________________________
 
 The `kubeadm upgrade plan` checks that your cluster is upgradeable and fetches the versions available to upgrade to in an user-friendly way.
 
+To check CoreDNS version, include the `--feature-gates=CoreDNS=true` flag to verify the CoreDNS version which will be installed in place of kube-dns.
+
 3. Pick a version to upgrade to and run. For example:
 
 ```shell
@@ -162,6 +164,7 @@ $ kubeadm upgrade apply v1.9.0
 [upgrade/kubelet] Now that your control plane is upgraded, please proceed with upgrading your kubelets in turn.
 ```
 
+To upgrade the cluster with CoreDNS as the default internal DNS, invoke `kubeadm upgrade apply` with the `--feature-gates=CoreDNS=true` flag.
 `kubeadm upgrade apply` does the following:
 
 - Checks that your cluster is in an upgradeable state:


### PR DESCRIPTION
Updated the docs to have better clarity about installing CoreDNS including correcting the `feature-gates` flag usage for CoreDNS.